### PR TITLE
Add a little bit of documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
+# JUnit Reporter
+
+Report JUnit test results as annotations on Github Pull Request and collect them on remote server.
+
+# Usage
+
+<!-- start usage -->
+```yaml
+- uses: allegro-actions/junit-reporter@v1
+  # Execute action if previous job fails or succeeds, otherwise it won't report failurs
+  # Default for workflows is success()
+  if: ${{ success() || failure() }}
+  with:
+    # JUnit XML report path in glob format
+    # Default: '**/TEST-*.xml'
+    path: '**/test-results/*/*.xml'
+```
+<!-- end usage -->
 ## Code in Main
 
 Install the dependencies

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ branding:
   color: 'green'
 inputs:
   token:
-    description: 'Used to add check informations'
+    description: 'Used to add check information'
     required: false
     default: ${{ github.token }}
   path:


### PR DESCRIPTION
Add some documentation with good practices, because by default adding just the job without a condition it wouldn't be run if CI test fail in the preceding job.